### PR TITLE
Update Copter-Cross Event Instructions

### DIFF
--- a/CopterCross/CopterCross-Event-Instructions
+++ b/CopterCross/CopterCross-Event-Instructions
@@ -8,6 +8,9 @@ Guest Arrival
 
 Welcome
 
+- First Rule of CopterCross: Breath.
+- Second Rule of CopterCross: Be Gentle and Slow.. 
+- Third Rule of CopterCross: Throttle down if you lose control
 
 1) Partner Up
    Instructions for how Pilot/Co-Pilot teams work together:
@@ -44,6 +47,11 @@ Welcome
      Map words to motion?
      Map words to controls?
      Map controls to motion?
+yaw-	rotating right or left
+pitch- forward and backward
+roll-	right and left
+uplift- fly up
+downfall- fly down
 
 5) Be the Copter
        Pilot / Co-Pilot practice
@@ -77,7 +85,7 @@ Welcome
             Land
     switch
 
-8) Walking Forward
+8) Walking Forward & Backward
     Take off, 
     hover at 3 feet.
     Fly forward 5 feet.
@@ -105,17 +113,66 @@ Welcome
 
     switch
 
-10) Front, Back and Side-to-Side
+10) Rotating
 
-11) Diagonals
+   Take off
+   Rotate to 10 o'clock
+   Fly forward and back to the origin.
+   Hover
+   Take off
+   Rotate to 2 o'clock
+   
+   Repeat 3 times
+   
+   switch
+  
+11) Nose-In Walking Forward and Backward (Hard)
+   Face nose towards pilot. 
+      Right will be left. Backwards will be forwards
+      Like balancing a stick. Whatever direction quad goes, stick goes
+   
+   Take off, 
+      hover at 3 feet.
+    Fly forward 5 feet.
+    hover.
+    fly backward to origin.
+    hover.
+    land.
 
-12) Rotating
+Repeat 3 times
 
-13) Banking
+    switch
 
-14) Figure 8's
+11) Nose-In Walking Side-to-Side (Hard)
+   Face nose towards pilot. 
+      Right will be left. Backwards will be forwards
+      Like balancing a stick. Whatever direction quad goes, stick goes
+      
+    Take off, 
+    hover at 3 feet.
+    Fly left 5 feet.
+    hover.
+    fly right to origin.
+    hover.
+    fly right 5 feet.
+    hover.
+    fly left to origin.
+    hover.
+    land.
 
-15) Flips
+    Repeat 3 times.
+
+    switch
+
+13) Walking with Scissors: Banking
+   Start going forward, about 5 mph
+   Apply small amount of aileron.
+   Continuously pull up on elevator
+   Continuously apply yaw. 
+
+14) Walking with Scissors: Figure 8's
+
+15) Walking with Scissors: Flips
 
 16) Fly by Screen
     Pilot / Co-Pilot collaboration


### PR DESCRIPTION
Added "First through Third Rules of CopterCross" Kind of like Rules of FightClub in Reverse mixed with "Unconference Rules
-Still incomplete, but as reminder for entire event.

Added Instructions for Walking with Scissors:
Nose-In Walking Forward and Backward
Nose-In Walking Side-to-Side
Banking
